### PR TITLE
refactor: context now passed as a property

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
   },
   "devDependencies": {
     "babel-preset-es2015-rollup": "^1.1.1",
-    "d3-path": "^0.1.5",
     "d3fc": "^7.0.0",
     "eslint": "^2.2.0",
     "eslint-config-airbnb": "^6.0.2",
@@ -40,5 +39,7 @@
     "semantic-release": "^4.3.5",
     "uglify-js": "^2.6.2"
   },
-  "dependencies": {}
+  "dependencies": {
+    "d3-path": "^0.1.5"
+  }
 }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,12 +1,13 @@
 import babel from 'rollup-plugin-babel';
 
 export default {
-  entry: 'index.js',
-  moduleName: 'fc_shape',
-  format: 'umd',
-  plugins: [ babel() ],
-  dest: 'build/d3fc-shape.js',
-  globals: {
-    d3: 'd3'
-  }
+    entry: 'index.js',
+    moduleName: 'fc_shape',
+    format: 'umd',
+    plugins: [ babel() ],
+    dest: 'build/d3fc-shape.js',
+    globals: {
+        'd3': 'd3',
+        'd3-path': 'd3_path'
+    }
 };

--- a/src/bar.js
+++ b/src/bar.js
@@ -1,10 +1,12 @@
+import { path } from 'd3-path';
 import functor from './functor';
 
 // Renders a bar series as an SVG path based on the given array of datapoints. Each
 // bar has a fixed width, whilst the x, y and height are obtained from each data
 // point via the supplied accessor functions.
-export default (context) => {
+export default () => {
 
+    let context           = null;
     let x                 = (d) => d.x;
     let y                 = (d) => d.y;
     let horizontalAlign   = 'center';
@@ -13,6 +15,8 @@ export default (context) => {
     let width             = functor(3);
 
     const bar = function(data, index) {
+
+        const buffer = context ? undefined : context = path();
 
         data.forEach(function(d, i) {
             const xValue    = x.call(this, d, index || i);
@@ -58,9 +62,16 @@ export default (context) => {
             );
         }, this);
 
-        return context;
+        return buffer && (context = null, buffer.toString() || null);
     };
 
+    bar.context = (_x) => {
+        if (!arguments.length) {
+            return context;
+        }
+        context = _x;
+        return bar;
+    };
     bar.x = (_x) => {
         if (!arguments.length) {
             return x;

--- a/src/boxPlot.js
+++ b/src/boxPlot.js
@@ -1,8 +1,10 @@
+import { path } from 'd3-path';
 import functor from './functor';
 
 // Renders a box plot series as an SVG path based on the given array of datapoints.
-export default (context) => {
+export default () => {
 
+    let context       = null;
     let value         = (d) => d.value;
     let median        = (d) => d.median;
     let upperQuartile = (d) => d.upperQuartile;
@@ -14,6 +16,8 @@ export default (context) => {
     let cap           = functor(0.5);
 
     const boxPlot = function(data) {
+
+        const buffer = context ? undefined : context = path();
 
         data.forEach(function(d, i) {
             // naming convention is for vertical orientation
@@ -67,9 +71,16 @@ export default (context) => {
             }
         });
 
-        return context;
+        return buffer && (context = null, buffer.toString()  || null);
     };
 
+    boxPlot.context = (_x) => {
+        if (!arguments.length) {
+            return context;
+        }
+        context = _x;
+        return boxPlot;
+    };
     boxPlot.value = (_x) => {
         if (!arguments.length) {
             return value;

--- a/src/candlestick.js
+++ b/src/candlestick.js
@@ -1,10 +1,12 @@
+import { path } from 'd3-path';
 import functor from './functor';
 
 // Renders a candlestick as an SVG path based on the given array of datapoints. Each
 // candlestick has a fixed width, whilst the x, open, high, low and close positions are
 // obtained from each point via the supplied accessor functions.
-export default (context) => {
+export default () => {
 
+    let context = null;
     let x       = (d) => d.date;
     let open    = (d) => d.open;
     let high    = (d) => d.high;
@@ -13,6 +15,8 @@ export default (context) => {
     let width   = functor(3);
 
     const candlestick = function(data) {
+
+        const buffer = context ? undefined : context = path();
 
         data.forEach(function(d, i) {
             const xValue        = x(d, i);
@@ -39,9 +43,16 @@ export default (context) => {
             context.lineTo(xValue, yLow);
         });
 
-        return context;
+        return buffer && (context = null, buffer.toString() || null);
     };
 
+    candlestick.context = (_x) => {
+        if (!arguments.length) {
+            return context;
+        }
+        context = _x;
+        return candlestick;
+    };
     candlestick.x = (_x) => {
         if (!arguments.length) {
             return x;

--- a/src/errorBar.js
+++ b/src/errorBar.js
@@ -1,8 +1,10 @@
+import { path } from 'd3-path';
 import functor from './functor';
 
 // Renders an error bar series as an SVG path based on the given array of datapoints.
-export default (context) => {
+export default () => {
 
+    let context   = null;
     let value     = (d) => d.x;
     let high      = (d) => d.high;
     let low       = (d) => d.low;
@@ -10,6 +12,8 @@ export default (context) => {
     let width     = functor(5);
 
     const errorBar = function(data) {
+
+        const buffer = context ? undefined : context = path();
 
         data.forEach(function(d, i) {
             // naming convention is for vertical orientation
@@ -36,9 +40,16 @@ export default (context) => {
             }
         });
 
-        return context;
+        return buffer && (context = null, buffer.toString() || null);
     };
 
+    errorBar.context = (_x) => {
+        if (!arguments.length) {
+            return context;
+        }
+        context = _x;
+        return errorBar;
+    };
     errorBar.value = (_x) => {
         if (!arguments.length) {
             return value;

--- a/src/ohlc.js
+++ b/src/ohlc.js
@@ -1,9 +1,12 @@
+import { path } from 'd3-path';
 import functor from './functor';
 
 // Renders an OHLC as an SVG path based on the given array of datapoints. Each
 // OHLC has a fixed width, whilst the x, open, high, low and close positions are
 // obtained from each point via the supplied accessor functions.
-export default (context) => {
+export default () => {
+
+    let context = null;
     let x       = (d) => d.date;
     let open    = (d) => d.open;
     let high    = (d) => d.high;
@@ -13,6 +16,8 @@ export default (context) => {
     let width   = functor(3);
 
     const ohlc = function(data) {
+
+        const buffer = context ? undefined : context = path();
 
         data.forEach(function(d, i) {
             const xValue      = x(d, i);
@@ -41,9 +46,16 @@ export default (context) => {
             }
         });
 
-        return context;
+        return buffer && (context = null, buffer.toString() || null);
     };
 
+    ohlc.context = (_x) => {
+        if (!arguments.length) {
+            return context;
+        }
+        context = _x;
+        return ohlc;
+    };
     ohlc.x = (_x) => {
         if (!arguments.length) {
             return x;

--- a/test/mainSpec.js
+++ b/test/mainSpec.js
@@ -1,4 +1,3 @@
-const d3Path = require('d3-path').path;
 const d3fcShape = require('../build/d3fc-shape');
 const fs = require('fs');
 const options = require('./data/options');
@@ -17,7 +16,7 @@ function checkResults(module, type) {
     const combinations = options[type].combinations;
 
     combinations.forEach((values, i) => {
-        const pathGen = module(d3Path());
+        const pathGen = module();
         values.forEach((val, i) => val ? pathGen[keys[i]](val) : null);
 
         expect(pathGen(data).toString()).toBe(results[i]);


### PR DESCRIPTION
Fixes #7

BREAKING CHANGE: The context can no longer be supplied as an argument
to the factory, instead it must be specified as a property. E.g.
```js
fc.bar().context(canvas.getContext())
```
The implementation defaults to using d3-path if no context is specified.